### PR TITLE
Add 'show build results only on a failed build' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Set to `1` to trigger a build on save. By default, this is set to `1`. I.e., Sub
 * **filename_filter**
 SublimeOnSaveBuild matches the name of the file being saved against this regular expression to determine if a build should be triggered. By default, the setting has a value of `"\\.(css|js|sass|less|scss)$"`.
 
+* **show_build_window_on_failure_only**
+Set to `1` if you want the build window to display only upon a failed build.  The default setting is `1`.  This setting can be configured on a project level.
+
 Usage
 -----
 1. Make sure you have a build operation set up in your Sublime Text 2 project and you are able to build using `Control+B` (Linux/Windows) or `Command+B` (OS X).

--- a/SublimeOnSaveBuild.py
+++ b/SublimeOnSaveBuild.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import re
-
+import functools
 
 class SublimeOnSaveBuild(sublime_plugin.EventListener):
     def on_post_save(self, view):
@@ -15,10 +15,39 @@ class SublimeOnSaveBuild(sublime_plugin.EventListener):
         # Load filename filter. Again, a project level setting takes precedence.
         filename_filter = view.settings().get('filename_filter', global_settings.get('filename_filter', '*'))
 
+        # Check if we should automatically hide the build window 
+        show_build_window_on_failure_only = view.settings().get('show_build_window_on_failure_only', global_settings.get('auto_hide_build_window', True))
+
         if not should_build:
             return
 
         if not re.search(filename_filter, view.file_name()):
             return
 
+        # show the 'exec' view before building, so we can read from it afterwards
+        self.output_view = view.window().get_output_panel("exec")
+
         view.window().run_command('build')
+
+        if show_build_window_on_failure_only:
+            self.num_polls = 0
+            # immediately hide the 'exec' panel. Will show it again later if there were errors
+            view.window().run_command("hide_panel", {"panel": "output.exec"})
+            # start polling for results every 100s
+            self.poll_for_results(view)
+
+    def poll_for_results(self, view):
+        build_finished = self.output_view.find('Finished', 0) != None
+
+        if build_finished:
+            errors = self.output_view.find('Error', 0)
+            if errors != None:
+                view.window().run_command("show_panel", {"panel": "output.exec"})
+        else:            
+            if self.num_polls < 50:
+                sublime.set_timeout(functools.partial(self.poll_for_results, view), 100)
+            else:
+                # show the window if the build took longer than the specified amount
+                view.window().run_command("show_panel", {"panel": "output.exec"})
+
+        self.num_polls += 1


### PR DESCRIPTION
This was a request from Issue #1 that I went ahead and implemented.  

One decision I made was to not show the build output at all if the build was successful.  I'm not sure if this is ideal, and would be happy to do the reverse (hide the window once the build succeeds).  

Feel free to complain and tell me to rewrite, change, etc.
