### PR TITLE
Sublime Text 3 Support

### DIFF
--- a/SublimeOnSaveBuild.py
+++ b/SublimeOnSaveBuild.py
@@ -5,7 +5,7 @@ import re
 
 class SublimeOnSaveBuild(sublime_plugin.EventListener):
     def on_post_save(self, view):
-        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        global_settings = sublime.load_settings(self.__class__.__name__+'.sublime-settings')
 
         # See if we should build. A project level build_on_save setting
         # takes precedence. To be backward compatible, we assume the global


### PR DESCRIPTION
I just updated the plugin to work in Sublime Text 3. 

I believe the Python **name** variable changed in Python 2 to Python 3 so I changed it to reference it a bit more specifically. Everything tested out fine in my brief testing.
