### PR TITLE
Don't included Sass partials in the automatic build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Do NOT edit the default SublimeOnSaveBuild settings. Your changes will be lost w
 Set to `1` to trigger a build on save. By default, this is set to `1`. I.e., SublimeOnSaveBuild attempts to build all projects. You can change this behavior and build only specific projects by configuring the user specific setting of `build_on_save` to `0` and project specific setting to `1`.
 
 * **filename_filter**
-SublimeOnSaveBuild matches the name of the file being saved against this regular expression to determine if a build should be triggered. By default, the setting has a value of `"\\.(css|js|sass|less|scss)$"`.
+SublimeOnSaveBuild matches the name of the file being saved against this regular expression to determine if a build should be triggered. By default, the setting has a value of `"^[^_]+\\.(css|js|sass|less|scss)$"`.
 
 Usage
 -----

--- a/SublimeOnSaveBuild.sublime-settings
+++ b/SublimeOnSaveBuild.sublime-settings
@@ -1,4 +1,4 @@
 {
-    "filename_filter": "\\.(css|js|sass|less|scss)$",
+    "filename_filter": "^[^_]+\\.(css|js|sass|less|scss)$",
     "build_on_save": 1
 }


### PR DESCRIPTION
This commit changes the filename_filter regex to not include sass partials. Those shouldn't be built. 
